### PR TITLE
Fixes to Exhibit Ad

### DIFF
--- a/css/CHSstyle.css
+++ b/css/CHSstyle.css
@@ -30,6 +30,11 @@ h5 {
 	font-weight: 700;
 	line-height: 20px;
 }
+h6 {
+	color: #121d1f;
+	font-weight: 400;
+	font-size: 34px;
+}
 .alert-box {
 	background-color: #DDFFE6;
 	color: #777;

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
 <div id="about">
   <div class="container">
     <div class="section-title text-center center">
-      <h2>"Early Chateaugay Lake" Exhibit Now Open</h2>
+      <h6>"Early Chateaugay Lake" Exhibit Now Open<br></h6>
       <hr>
     </div>
     <div class="row">
@@ -518,7 +518,7 @@
   <div class="container text-center">
     <div class="fnav">
       <p>Copyright &copy; 2021 Chateaugay Historical Society. </br>
-	  Last Modified [June 28, 2022]. Designed by Chateaugay Historical Society. Template by <a href="http://www.templatewire.com" rel="nofollow">TemplateWire</a></p>
+	  Last Modified [July 15, 2022]. Designed by Chateaugay Historical Society. Template by <a href="http://www.templatewire.com" rel="nofollow">TemplateWire</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixed spacing in title for mobile version so text wouldn't be overlapped. Double checked response text in paragraph block. Added h6 header properties to css to fix title spacing