### PR TITLE
Replaced Gmail

### DIFF
--- a/About.html
+++ b/About.html
@@ -229,7 +229,7 @@
               <div class="u-container-layout u-valign-bottom-sm u-valign-bottom-xs u-container-layout-1">
                 <h1 class="u-align-center u-text u-text-default u-text-1">Newsletter</h1>
                 <p class="u-align-center u-text u-text-2"> For a complete listing of all of the Chateaugay Historical Society quarterly newsletters since 2007, and the individual articles contained in each issue, click on the Index button below. Four quarterly newsletters are included with an annual membership (please see previous section if you would like to become a member). Back issues can be ordered by both members and non-members for $3 each (tax included). If an issue needs to be mailed to you, the charge will be $1 per issue. For example, if you are ordering three issues, you would remit $12 ($9 for the three issues and $3 for mailing). Of course, if you are picking up back issues in person, there would be no postage charge.&nbsp;<br>
-                  <br>Contact us at chathistsoc@gmail.com to place your order for mailing or pick-up.
+                  <br>Contact us to place your order for mailing or pick-up.
                 </p>
                 <a href="files/CHS_NewsletterIndex.pdf" class="u-border-2 u-border-black u-btn u-button-style u-file-link u-hover-grey-80 u-none u-text-black u-text-hover-white u-btn-1" target="_blank"><span class="u-file-icon u-icon"><img src="images/2810390.png" alt=""></span>&nbsp;Newsletter Index
                 </a>
@@ -256,7 +256,7 @@
           </a>
         </div>
         <p class="u-align-center-lg u-align-center-md u-align-center-xl u-align-center-xs u-text u-text-1">© 2023 Chateaugay Historical Society<br> Designed by Chateaugay Historical Society using <a href="https://nicepage.com/html-templates" class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-palette-1-base u-btn-1" target="_blank">nicepage</a>
-          <br>Last Modified May 2023.<br>
+          <br>Last Modified June 2023.<br>
         </p>
       </div></footer>
     <section class="u-backlink u-clearfix u-grey-80">

--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@ County.&nbsp;&nbsp;
 </g></svg></span>
                 <h5 class="u-text u-text-7">Email</h5>
                 <p class="u-align-center-lg u-align-center-md u-align-center-sm u-align-center-xs u-text u-text-8">
-                  <a href="mailto:chathistsoc@gmail.com" class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-palette-1-base u-btn-1">chathistsoc@gmail.com</a>
+                  <a href="mailto:chs@chateaugayhistory.org" class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-palette-1-base u-btn-1">chs@chateaugayhistory.org</a>
                 </p>
               </div>
             </div>
@@ -460,7 +460,7 @@ background-color: #333333 !important
           </a>
         </div>
         <p class="u-align-center-lg u-align-center-md u-align-center-xl u-align-center-xs u-text u-text-1">© 2023 Chateaugay Historical Society<br> Designed by Chateaugay Historical Society using <a href="https://nicepage.com/html-templates" class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-palette-1-base u-btn-1" target="_blank">nicepage</a>
-          <br>Last Modified May 2023.<br>
+          <br>Last Modified June 2023.<br>
         </p>
       </div></footer>
     <section class="u-backlink u-clearfix u-grey-80">


### PR DESCRIPTION
Replaced Gmail Address with new email. Took email out of text on about page so it only needs to be updated on Contact section.