### PR TITLE
Removal

### DIFF
--- a/About.html
+++ b/About.html
@@ -144,13 +144,12 @@
                     <li>Rose Mary Hiscock, Secretary</li>
                     <li>Michael Jarvis, Treasurer</li>
                     <li>Bob Bessette</li>
-                    <li>Cheryl Cook</li>
                     <li>Lynn Harrigan</li>
                     <li>Katelyn Legacy-Roulston</li>
                     <li>Edith Lopardo</li>
                     <li>Jo Ellen Saumier</li>
                   </ul>
-                  <p class="u-text u-text-5">There are currently two vacant trustee positions</p>
+                  <p class="u-text u-text-5">There are currently three vacant trustee positions</p>
                   <h6 class="u-text u-text-6">Trustees Emeretii<br>
                   </h6>
                   <ul class="u-text u-text-7">
@@ -256,7 +255,7 @@
           </a>
         </div>
         <p class="u-align-center-lg u-align-center-md u-align-center-xl u-align-center-xs u-text u-text-1">© 2023 Chateaugay Historical Society<br> Designed by Chateaugay Historical Society using <a href="https://nicepage.com/html-templates" class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-palette-1-base u-btn-1" target="_blank">nicepage</a>
-          <br>Last Modified June 2023.<br>
+          <br>Last Modified October 2023.<br>
         </p>
       </div></footer>
     <section class="u-backlink u-clearfix u-grey-80">


### PR DESCRIPTION
Removed Cheryl Cook from active trustees; changed vacant positions to 3