### PR TITLE
Link Removal

### DIFF
--- a/Resources.html
+++ b/Resources.html
@@ -136,9 +136,6 @@
                   <p class="u-align-center u-text u-text-default u-text-12">
                     <a class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-hover-custom-color-1 u-text-palette-1-base u-btn-8" href="https://home.rootsweb.com/" target="_blank">RootsWeb</a>
                   </p>
-                  <p class="u-align-center u-text u-text-default u-text-12">
-                    <a class="u-active-none u-border-none u-btn u-button-link u-button-style u-hover-none u-none u-text-hover-custom-color-1 u-text-palette-1-base u-btn-8" href="https://www.aaastateofplay.com/genealogy-for-kids-building-a-family-tree/" target="_blank">Genealogy for Kids: Building a Family Tree</a>
-                  </p>
                 </div>
               </div>
               <div class="u-container-style u-layout-cell u-size-15 u-size-30-md u-layout-cell-3">


### PR DESCRIPTION
Genealogy for Kids from aaastateofplay.com. Decided not to include links that weren't local or from a historical/research organization.